### PR TITLE
[DEV] update to kernel 6.5.0

### DIFF
--- a/atecc/atecc.c
+++ b/atecc/atecc.c
@@ -34,8 +34,7 @@ static void getCRC16LittleEndian(size_t length, const uint8_t *data,
 	crc_le[1] = (uint8_t) (crc >> 8);
 }
 
-static int atecc_i2c_probe(struct i2c_client *client,
-		const struct i2c_device_id *id) {
+static int atecc_i2c_probe(struct i2c_client *client) {
 	uint8_t i;
 	int ret = -1;
 	uint8_t i2c_wake_msg = 0x00; // msg sent to I2C bus to wake up ATECC608A from sleep state

--- a/module.c
+++ b/module.c
@@ -4489,8 +4489,7 @@ static ssize_t devAttrSerialRs232Rs485Inv_store(struct device *dev,
 	return count;
 }
 
-static int ionopimax_i2c_probe(struct i2c_client *client,
-		const struct i2c_device_id *id) {
+static int ionopimax_i2c_probe(struct i2c_client *client) {
 	struct ionopimax_i2c_data *data;
 
 	data = devm_kzalloc(&client->dev, sizeof(struct ionopimax_i2c_data),
@@ -4681,7 +4680,7 @@ static int __init ionopimax_init(void) {
 	wiegandInit(&w1);
 	wiegandInit(&w2);
 
-	pDeviceClass = class_create(THIS_MODULE, "ionopimax");
+	pDeviceClass = class_create("ionopimax");
 	if (IS_ERR(pDeviceClass)) {
 		pr_alert("ionopimax: * | failed to create device class\n");
 		goto fail;

--- a/wiegand/wiegand.c
+++ b/wiegand/wiegand.c
@@ -7,6 +7,10 @@
 
 int wCount = 0;
 
+static inline int gpio_set_debounce(unsigned gpio, unsigned debounce) {
+    return gpiod_set_debounce(gpio_to_desc(gpio), debounce);
+}
+
 static enum hrtimer_restart wiegandTimerHandler(struct hrtimer *tmr) {
 	struct WiegandBean *w;
 	w = container_of(tmr, struct WiegandBean, timer);


### PR DESCRIPTION
device: ionopi-max
linux: ubuntu server 23.10 for rpi

I update the driver to build on the current kernel 6.5.0 on ubuntu. 

But after installing-it, and restart the device, it does not work